### PR TITLE
added whitelist in user doc

### DIFF
--- a/docs/data_user.md
+++ b/docs/data_user.md
@@ -89,6 +89,12 @@ output
     └ otherresults.nii.gz
 ```
 
+#### Whitelisting
+
+The participant and group-level analysis result in a number of files, some of which are only temporary work-in-progress, whereas others represent the primary research outcomes of the analysis pipeline. The data user has to provide a text file `whitelist.txt` that lists all the desired outcomes, i.e., all files resulting from the group-level analysis that are to be retained. Noise calibration will be done on the numerical data in these files, and a differentially private version of these files will be shared with the data user. 
+
+Files that are not in the `whitelist.txt` will never be shared with the data user.
+
 ## Storage requirements
 
 The data user must specify to the platform operator what the storage requirements are for the participant- and group-level analyses. How many file are created, how much storage does that require, what is the retention period of the intermediate data, and what data files comprise the final results for the data user.
@@ -110,10 +116,6 @@ The participant-level analysis can be done one subject at the time, but can also
 ### Group level
 
 During the group-level analysis, the data from multiple participants is combined into an aggregate group-level output that provides the answer to the data user's research question. The group level analysis might require access to the original input data, and might also require access to intermediate results that are computed during the participant-level analysis.
-
-#### whitelisting
-
-The group level output is taken from a whitelist.txt file that must list all the desired outcomes.
 
 ### Software licenses
 

--- a/docs/data_user.md
+++ b/docs/data_user.md
@@ -111,6 +111,10 @@ The participant-level analysis can be done one subject at the time, but can also
 
 During the group-level analysis, the data from multiple participants is combined into an aggregate group-level output that provides the answer to the data user's research question. The group level analysis might require access to the original input data, and might also require access to intermediate results that are computed during the participant-level analysis.
 
+#### whitelisting
+
+The group level output is taken from a whitelist.txt file that must list all the desired outcomes.
+
 ### Software licenses
 
 The SIESTA platform or its platform operators does not provide the software and/or licenses for the software that you may want to use in your analysis pipeline. When implementing the container that runs the analysis pipeline, you should take the appropriate measures such that the software can be installed and that it can be both legally and technically used.

--- a/usecase-2.1/README.md
+++ b/usecase-2.1/README.md
@@ -72,6 +72,8 @@ Average Matching Cells per Row: 254.03
 Standard Deviation of Matching Cells per Row: 10.15
 ```
 
+If full leakage is not at 0%, the scrambler should be re-run. Partial leakage is left at the appreciation of the data right holder.
+
 ### Data citation
 
 Yulin Wang and Wei Duan and Debo Dong and Lihong Ding and Xu Lei (2022). A test-retest resting and cognitive state EEG dataset. OpenNeuro. [Dataset] doi: doi:10.18112/openneuro.ds004148.v1.0.1


### PR DESCRIPTION
probably needs extra explanation - should those listed file only by scalars, vectors, matrices (as medical images) - what about structures, objects, or figures